### PR TITLE
fix(projects): resolve project names without enumerating the workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **`projects tasks` and `projects list` no longer 400 in large workspaces** — resolving a project by name previously enumerated *every* project in the workspace, and the unbounded first request returned `400: The result is too large`. `FetchAllProjects` now always requests a bounded page (≤100), and `projects tasks <name>` resolves via the typeahead API (numeric IDs are fetched directly), the same ceiling-free path `projects list -q` uses.
+
 ## [3.3.1] - 2026-06-23
 
 ### Fixed

--- a/claude-plugin/skills/using-asana-cli/SKILL.md
+++ b/claude-plugin/skills/using-asana-cli/SKILL.md
@@ -173,6 +173,35 @@ asana projects sections create --help
 asana projects tasks --help
 ```
 
+Accepts a project **name** or **numeric ID**. Both resolve efficiently — name lookups use the typeahead API (no project-count ceiling), so this works even in workspaces with thousands of projects.
+
+### List tasks in a specific SECTION of a project
+
+**Sections are not assignees.** A project can have a section *named after a person* (e.g. a "Tom" section) that is completely independent of who its tasks are assigned to. "Tasks in the Tom section" and "tasks assigned to Tom" are **different questions with different answers** — do not substitute one for the other.
+
+To get the tasks that belong to a section, use `--sections` (groups tasks by their real section membership), then filter by section name:
+
+```bash
+# Tasks that live in the "Tom" section (section membership — NOT assignee)
+asana projects tasks "Outgoing Tasks" --sections --json \
+  | jq '.[] | select(.section == "Tom") | .tasks'
+
+# Count them
+asana projects tasks "Outgoing Tasks" --sections --json \
+  | jq '.[] | select(.section == "Tom") | .tasks | length'
+```
+
+Contrast with assignee filtering, which ignores sections entirely:
+
+```bash
+# Tasks ASSIGNED to Tom anywhere in the project (may span many sections,
+# and may miss Tom-section tasks assigned to someone else or unassigned)
+asana tasks search --project <project-id> --json \
+  | jq '.[] | select(.assignee.id == "<tom-gid>")'
+```
+
+**Caveat — `--sections` uses a board-view endpoint.** Section-scoped task listing relies on Asana's `sections/{id}/tasks` endpoint, which is populated for **board-layout** projects. On a list-layout project a section may return no tasks even when the Asana web UI shows some. If `--sections` yields empty sections that you know are non-empty, say so explicitly rather than silently falling back to an assignee filter — see "Answering read queries honestly" below.
+
 ## Users
 
 ### List workspace users
@@ -236,11 +265,22 @@ When the user describes an action in natural language, translate it to the corre
 | "assign to me" / "I'll take this" | `--assignee me` | |
 | "assign to Chris" | `--assignee "Chris"` | Name matching works on create, update, AND search |
 | "find Tom's tasks" / "search Tom's stuff" | `--assignee "Tom"` | Search resolves names to IDs automatically |
+| "tasks in Tom's section" / "the Tom column" / "what's in the Tom section" | `projects tasks <project> --sections` + filter by section name | A **section** named after a person is NOT the same as its assignee. See "List tasks in a specific SECTION". Do not translate this to `--assignee`. |
 | "find the outgoing project" / "which project is X in?" | `asana projects list -q "outgoing"` | Uses typeahead API — no 100-project ceiling |
 | "mark it done" / "complete this" | `--complete` | Update command only |
 | "move it to Project X" | `asana tasks move <task-id>` | Don't delete and recreate |
 
 **Critical rule:** For `--due today` and `--due tomorrow`, ALWAYS pass the keyword literally. The CLI resolves it using `time.Now()` on the local machine, which is more reliable than the agent computing a date from session context (which may be stale or in a different timezone).
+
+## Answering read queries honestly
+
+Reads deserve the same rigor as writes. When you search, filter, or count tasks:
+
+1. **Answer the question that was asked.** If you were asked for a *section's* tasks, return section membership — not a proxy like "tasks assigned to the person the section is named after." If the two happen to differ, that difference is the point.
+2. **Never silently swap the query.** If the intended approach fails (an endpoint errors, returns empty, or hits a limit), STOP and say what failed. Do not quietly substitute a different filter and present its results as if they answered the original question. A wrong-but-confident count is worse than "I couldn't get that directly — here's what I tried."
+3. **Don't present a proxy count as the real count.** "24 tasks in the Tom section" and "26 tasks assigned to Tom" are different numbers answering different questions. Label which one you actually computed.
+4. **Watch for silent truncation.** `--limit N` caps totals; if a result set is exactly N, more may exist. State when a count could be truncated.
+5. **Large workspace? Resolve by name or ID directly** (`projects tasks`, `projects list -q`) — these use the typeahead API and won't hit the "result is too large" 400 that unbounded enumeration triggers.
 
 ## Post-Mutation Verification
 

--- a/claude-plugin/skills/using-asana-cli/references/TROUBLESHOOTING.md
+++ b/claude-plugin/skills/using-asana-cli/references/TROUBLESHOOTING.md
@@ -29,7 +29,7 @@ Ensure you're running the fork with non-interactive support (version should show
 |-------|-------|-----|
 | `unknown flag: --name` | Running upstream v1.2.0 (no flag support) | Install the fork: `asana upgrade --yes` |
 | `could not prompt: EOF` | Interactive prompt in non-TTY context | Use flags to skip prompts (`-n`, `-a`, `-p`) |
-| `The result is too large` | API pagination issue | Use `--search`/`-q` to narrow results, or commands that paginate properly |
+| `The result is too large` | Unbounded project enumeration in a large workspace (fixed in-CLI for `projects tasks`/`projects list` as of the name-resolution fix). If seen on an older build: `asana upgrade --yes` | Resolve projects by name or ID directly (`projects tasks "Name"`, `projects list -q "Name"`) — these use the typeahead API and never enumerate the whole workspace |
 | `section "X" not found in project` | Section name doesn't exist | Run `asana projects sections "Project Name"` to see available sections |
 | `assignee "X" not found` | Name doesn't match any workspace user | Run `asana users list` to see available users; try partial name match |
 | `followers: Cannot write this property` | Using followers in update request body | Followers must be added via `AddFollowers` endpoint (handled in fork) |

--- a/pkg/cmd/projects/shared/http.go
+++ b/pkg/cmd/projects/shared/http.go
@@ -2,19 +2,30 @@ package shared
 
 import "github.com/timwehrle/asana/internal/api/asana"
 
+const maxPageSize = 100
+
 func FetchAllProjects(
 	client *asana.Client,
 	workspace *asana.Workspace,
 	limit int,
 ) ([]*asana.Project, error) {
-	initialCapacity := 100
+	initialCapacity := maxPageSize
 	if limit > 0 {
 		initialCapacity = limit
 	}
 
+	// Always request a bounded page. The Asana API rejects an unbounded
+	// projects request with "400: The result is too large", so page size is
+	// fixed at 100 (the API max) regardless of the caller's total cap; `limit`
+	// only truncates the accumulated results below.
+	pageSize := maxPageSize
+	if limit > 0 && limit < maxPageSize {
+		pageSize = limit
+	}
+
 	projects := make([]*asana.Project, 0, initialCapacity)
 	options := &asana.Options{
-		Limit:  limit,
+		Limit: pageSize,
 		Fields: []string{
 			"name",
 			"archived",

--- a/pkg/cmd/projects/shared/http_test.go
+++ b/pkg/cmd/projects/shared/http_test.go
@@ -1,0 +1,67 @@
+package shared
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/h2non/gock"
+	"github.com/timwehrle/asana/internal/api/asana"
+)
+
+type obj map[string]any
+
+// TestFetchAllProjects_NeverSendsUnboundedRequest guards the large-workspace
+// bug: FetchAllProjects must always request a bounded page (limit=100) so the
+// Asana API never returns "400: The result is too large". Passing limit=0
+// ("no total cap") must NOT translate into an unbounded first request.
+func TestFetchAllProjects_NeverSendsUnboundedRequest(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://app.asana.com").
+		Get("/api/1.0/workspaces/WS1/projects").
+		MatchParam("limit", "100").
+		Reply(200).
+		JSON(obj{"data": []obj{
+			{"gid": "p1", "name": "Alpha"},
+			{"gid": "p2", "name": "Beta"},
+		}})
+
+	client := asana.NewClient(http.DefaultClient)
+	projects, err := FetchAllProjects(client, &asana.Workspace{ID: "WS1"}, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(projects) != 2 {
+		t.Fatalf("expected 2 projects, got %d", len(projects))
+	}
+	if !gock.IsDone() {
+		t.Errorf("expected the limit=100 request to be made; pending mocks: %d", len(gock.Pending()))
+	}
+}
+
+// TestFetchAllProjects_LimitCapsTotal verifies that a positive limit caps the
+// total number of results returned, independent of page size.
+func TestFetchAllProjects_LimitCapsTotal(t *testing.T) {
+	defer gock.Off()
+
+	page := make([]obj, 100)
+	for i := range page {
+		page[i] = obj{"gid": "p", "name": "P"}
+	}
+
+	// A cap below the page maximum is itself a valid bounded page size.
+	gock.New("https://app.asana.com").
+		Get("/api/1.0/workspaces/WS1/projects").
+		MatchParam("limit", "25").
+		Reply(200).
+		JSON(obj{"data": page})
+
+	client := asana.NewClient(http.DefaultClient)
+	projects, err := FetchAllProjects(client, &asana.Workspace{ID: "WS1"}, 25)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(projects) != 25 {
+		t.Fatalf("expected results capped at 25, got %d", len(projects))
+	}
+}

--- a/pkg/cmd/projects/tasks/tasks.go
+++ b/pkg/cmd/projects/tasks/tasks.go
@@ -194,6 +194,12 @@ func resolveProject(
 }
 
 // isProjectID reports whether s looks like an Asana gid (all digits).
+//
+// This is intentionally greedy: an all-digit input is always treated as a gid
+// and fetched directly, never resolved by name. A project literally named
+// after a bare integer (e.g. "2024") is therefore unreachable by that name —
+// an accepted trade-off, since such names are vanishingly rare and inherently
+// ambiguous with gids anyway.
 func isProjectID(s string) bool {
 	if s == "" {
 		return false

--- a/pkg/cmd/projects/tasks/tasks.go
+++ b/pkg/cmd/projects/tasks/tasks.go
@@ -129,7 +129,18 @@ func selectProject(
 	client *asana.Client,
 	workspaceID string,
 ) (*asana.Project, error) {
-	projects, err := shared.FetchAllProjects(client, &asana.Workspace{ID: workspaceID}, 0)
+	ws := &asana.Workspace{ID: workspaceID}
+
+	// If a project name/ID was provided, resolve it directly instead of
+	// enumerating every project in the workspace — enumeration is expensive
+	// and, in large workspaces, the unbounded first page can 400 with
+	// "The result is too large".
+	if opts.ProjectName != "" {
+		return resolveProject(client, ws, opts.ProjectName)
+	}
+
+	// Otherwise, enumerate for interactive selection.
+	projects, err := shared.FetchAllProjects(client, ws, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch projects: %w", err)
 	}
@@ -139,12 +150,7 @@ func selectProject(
 		return nil, errors.New("no projects found")
 	}
 
-	// If a project name/ID was provided, find it directly
-	if opts.ProjectName != "" {
-		return findProject(projects, opts.ProjectName)
-	}
-
-	// Otherwise, prompt interactively
+	// Prompt interactively
 	projectNames := make([]string, len(projects))
 	for i, project := range projects {
 		projectNames[i] = project.Name
@@ -156,6 +162,48 @@ func selectProject(
 	}
 
 	return projects[index], nil
+}
+
+// resolveProject resolves a project by ID or name without enumerating the
+// whole workspace. Numeric input is treated as a gid and fetched directly;
+// everything else is resolved through the workspace typeahead API (the same
+// endpoint `projects list -q` uses), which has no project-count ceiling.
+func resolveProject(
+	client *asana.Client,
+	ws *asana.Workspace,
+	nameOrID string,
+) (*asana.Project, error) {
+	if isProjectID(nameOrID) {
+		project := &asana.Project{}
+		project.ID = nameOrID
+		if err := project.Fetch(client); err != nil {
+			return nil, fmt.Errorf("project %q not found: %w", nameOrID, err)
+		}
+		return project, nil
+	}
+
+	projects, err := ws.SearchProjects(client, nameOrID, 100)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search projects: %w", err)
+	}
+	if len(projects) == 0 {
+		return nil, fmt.Errorf("project %q not found in workspace", nameOrID)
+	}
+
+	return findProject(projects, nameOrID)
+}
+
+// isProjectID reports whether s looks like an Asana gid (all digits).
+func isProjectID(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func findProject(projects []*asana.Project, name string) (*asana.Project, error) {

--- a/pkg/cmd/projects/tasks/tasks_test.go
+++ b/pkg/cmd/projects/tasks/tasks_test.go
@@ -2,13 +2,74 @@ package tasks
 
 import (
 	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/h2non/gock"
 	"github.com/timwehrle/asana/internal/api/asana"
 	"github.com/timwehrle/asana/pkg/iostreams"
 )
+
+type obj map[string]any
+
+// TestSelectProject_ByNameUsesTypeahead verifies that resolving a project by
+// name uses the workspace typeahead endpoint (constant-cost) rather than
+// enumerating every project in the workspace. Only the typeahead endpoint is
+// mocked; if selectProject fell back to /workspaces/{id}/projects it would hit
+// an unmocked endpoint and error.
+func TestSelectProject_ByNameUsesTypeahead(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://app.asana.com").
+		Get("/api/1.0/workspaces/WS1/typeahead").
+		MatchParam("resource_type", "project").
+		Reply(200).
+		JSON(obj{"data": []obj{
+			{"gid": "1204651307630741", "name": "Outgoing Tasks"},
+		}})
+
+	opts := &TasksOptions{ProjectName: "Outgoing Tasks"}
+	client := asana.NewClient(http.DefaultClient)
+
+	project, err := selectProject(opts, client, "WS1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if project.ID != "1204651307630741" {
+		t.Fatalf("expected project 1204651307630741, got %q", project.ID)
+	}
+	if !gock.IsDone() {
+		t.Errorf("expected typeahead request; pending mocks: %d", len(gock.Pending()))
+	}
+}
+
+// TestSelectProject_ByIDFetchesDirectly verifies that a numeric project ID is
+// fetched directly by ID rather than searched by name (typeahead matches on
+// name, not gid).
+func TestSelectProject_ByIDFetchesDirectly(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://app.asana.com").
+		Get("/api/1.0/projects/1204651307630741").
+		Reply(200).
+		JSON(obj{"data": obj{"gid": "1204651307630741", "name": "Outgoing Tasks"}})
+
+	opts := &TasksOptions{ProjectName: "1204651307630741"}
+	client := asana.NewClient(http.DefaultClient)
+
+	project, err := selectProject(opts, client, "WS1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if project.ID != "1204651307630741" {
+		t.Fatalf("expected project 1204651307630741, got %q", project.ID)
+	}
+	if !gock.IsDone() {
+		t.Errorf("expected direct fetch by ID; pending mocks: %d", len(gock.Pending()))
+	}
+}
 
 // boolPtr is a test helper for creating *bool values.
 func boolPtr(b bool) *bool { return &b }


### PR DESCRIPTION
## Problem

`asana projects tasks <name>` and `asana projects list` (without `-q`) resolved a project name by calling `FetchAllProjects(limit=0)`, which enumerates **every** project in the workspace. In large workspaces the unbounded first page returns:

```
400: The result is too large. You should use pagination
```

…breaking both commands outright. The `--sections` flag looked like the culprit, but the failure was actually at project *resolution*, before tasks/sections were ever touched.

## Root cause

- `Options.Limit` is `url:"limit,omitempty"`, so `limit=0` is dropped from the query → the request goes out unbounded → Asana 400s.
- `FetchAllProjects` passed the caller's `limit` straight through as the page size, so `limit=0` meant "no limit param at all."

## Fix

- **`FetchAllProjects`** now always requests a bounded page (`min(limit, 100)`) and treats `limit` purely as a total cap. Never sends an unbounded request.
- **`projects tasks <name>`** resolves via the typeahead API (`SearchProjects`) — the same ceiling-free path `projects list -q` already uses. Numeric input is fetched directly by gid. Full enumeration is now used **only** for interactive selection (which is itself now bounded).
- **Skill docs** (`claude-plugin/.../using-asana-cli`): added a section-membership workflow with an explicit **section-vs-assignee disambiguation** (a section *named* "Tom" ≠ tasks *assigned to* Tom), the board-view `--sections` caveat, and an "Answering read queries honestly" discipline against silently substituting a proxy query when the intended one fails.

## Verification

- New tests (`gock`-mocked): `FetchAllProjects` never sends an unbounded request and caps totals; `selectProject` resolves by name via typeahead and by ID via direct fetch, without enumerating.
- Full suite green (`go test ./...`).
- Live API: `projects list`, `projects tasks "Outgoing Tasks"`, `projects tasks <id>`, and `projects tasks --sections` all succeed where they previously 400'd. The "Tom" **section** correctly returns 24 tasks by membership (vs. 26 assignee-matched — the exact confusion this fixes).

## Context

Discovered via a hotline review of an agent that reported an assignee-matched count as a section total: the section path 400'd, and it silently pivoted to assignee filtering. This fixes the 400 and closes the doc gaps that allowed the pivot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8yaWCaKUgFBvFENqBVtDQ